### PR TITLE
fix: reference being ignored in request to the GitHub API

### DIFF
--- a/backend/infrastructure/network/getWorkflowStatus.ts
+++ b/backend/infrastructure/network/getWorkflowStatus.ts
@@ -8,7 +8,8 @@ import { getCleanStatus } from '../../application/getCleanStatus';
 export async function getWorkflowStatus(input: RepoInput): Promise<GitHubStatus> {
   const { owner, repo, ref } = input;
   const token = process.env.GITHUB_TOKEN || '';
-  const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=main&per_page=25`;
+  
+  const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${ref}&per_page=25`;
 
   const headers: Record<string, any> = {
     Accept: 'application/vnd.github+json'

--- a/backend/infrastructure/network/getWorkflowStatus.ts
+++ b/backend/infrastructure/network/getWorkflowStatus.ts
@@ -8,7 +8,6 @@ import { getCleanStatus } from '../../application/getCleanStatus';
 export async function getWorkflowStatus(input: RepoInput): Promise<GitHubStatus> {
   const { owner, repo, ref } = input;
   const token = process.env.GITHUB_TOKEN || '';
-  
   const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${ref}&per_page=25`;
 
   const headers: Record<string, any> = {

--- a/backend/infrastructure/network/getWorkflowStatus.ts
+++ b/backend/infrastructure/network/getWorkflowStatus.ts
@@ -8,6 +8,7 @@ import { getCleanStatus } from '../../application/getCleanStatus';
 export async function getWorkflowStatus(input: RepoInput): Promise<GitHubStatus> {
   const { owner, repo, ref } = input;
   const token = process.env.GITHUB_TOKEN || '';
+  
   const url = `https://api.github.com/repos/${owner}/${repo}/actions/runs?branch=${ref}&per_page=25`;
 
   const headers: Record<string, any> = {

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,7 +31,7 @@ package:
 
 custom:
   config:
-    awsAccountNumber: ${param:awsAccountNumber, aws:accountId} # SET THIS
+    awsAccountNumber: ${param:awsAccountNumber, aws:accountId}
     #GITHUB_CREDENTIALS: ${ssm:/aws/reference/secretsmanager/GitHub} # If using AWS Secrets Manager
   aws:
     tableName: ${self:service}-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,7 +31,7 @@ package:
 
 custom:
   config:
-    awsAccountNumber: ${param:awsAccountNumber, aws:accountId}
+    awsAccountNumber: ${param:awsAccountNumber, aws:accountId, ''} # SET THIS
     #GITHUB_CREDENTIALS: ${ssm:/aws/reference/secretsmanager/GitHub} # If using AWS Secrets Manager
   aws:
     tableName: ${self:service}-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,7 +31,7 @@ package:
 
 custom:
   config:
-    awsAccountNumber: ${param:awsAccountNumber, '123412341234'} # SET THIS
+    awsAccountNumber: ${param:awsAccountNumber, aws:accountId} # SET THIS
     #GITHUB_CREDENTIALS: ${ssm:/aws/reference/secretsmanager/GitHub} # If using AWS Secrets Manager
   aws:
     tableName: ${self:service}-${self:provider.stage}
@@ -57,7 +57,7 @@ functions:
     environment:
       REGION: ${aws:region}
       TABLE_NAME: ${self:custom.aws.tableName}
-      GITHUB_TOKEN: '' # SET THIS
+      GITHUB_TOKEN: ${env:GITHUB_TOKEN} # SET THIS
       #GITHUB_TOKEN:  ${self:custom.config.GITHUB_CREDENTIALS.TOKEN} # If using AWS Secrets Manager
 
 resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,7 +57,7 @@ functions:
     environment:
       REGION: ${aws:region}
       TABLE_NAME: ${self:custom.aws.tableName}
-      GITHUB_TOKEN: ${env:GITHUB_TOKEN} # SET THIS
+      GITHUB_TOKEN: '' # SET THIS
       #GITHUB_TOKEN:  ${self:custom.config.GITHUB_CREDENTIALS.TOKEN} # If using AWS Secrets Manager
 
 resources:


### PR DESCRIPTION
1. Changes the default account id to `aws:accountid` which is [available as a default AWS variable](https://www.serverless.com/framework/docs/providers/aws/guide/variables).
2. Fixes the `getWorkflowStatus` function which is ignoring the `ref` input.